### PR TITLE
Fix ValueError in unitree_h1_env: Use default_factory for mutable default field 'kp'

### DIFF
--- a/dial_mpc/envs/unitree_h1_env.py
+++ b/dial_mpc/envs/unitree_h1_env.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, Sequence, Tuple, Union, List
 
 import numpy as np
@@ -24,7 +24,7 @@ from dial_mpc.utils.io_utils import get_model_path
 
 @dataclass
 class UnitreeH1WalkEnvConfig(BaseEnvConfig):
-    kp: Union[float, jax.Array] = jnp.array(
+    kp: Union[float, jax.Array] = field(default_factory=lambda: jnp.array(
         [
             200.0,
             200.0,
@@ -46,8 +46,8 @@ class UnitreeH1WalkEnvConfig(BaseEnvConfig):
             60.0,
             60.0,  # right shoulder, elbow
         ]
-    )
-    kd: Union[float, jax.Array] = jnp.array(
+    ))
+    kd: Union[float, jax.Array] = field(default_factory=lambda: jnp.array(
         [
             5.0,
             5.0,
@@ -69,7 +69,7 @@ class UnitreeH1WalkEnvConfig(BaseEnvConfig):
             1.5,
             1.5,  # right shoulder, elbow
         ]
-    )
+    ))
     default_vx: float = 1.0
     default_vy: float = 0.0
     default_vyaw: float = 0.0


### PR DESCRIPTION
Hey!

The code breaks in newer versions of Python because of how it handles mutable defaults in dataclasses (see [PEP 557](https://peps.python.org/pep-0557/#mutable-default-values)), this PR fixes the issue.

P.S.
(The error was already reported in this [issue](https://github.com/LeCAR-Lab/dial-mpc/issues/3))